### PR TITLE
Add sidecar support

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -53,3 +53,12 @@ type RedisExporter struct {
 	ImagePullPolicy corev1.PullPolicy            `json:"imagePullPolicy,omitempty"`
 	EnvVars         *[]corev1.EnvVar             `json:"env,omitempty"`
 }
+
+// Sidecar for each Redis pods
+type Sidecar struct {
+	Name            string                       `json:"name"`
+	Image           string                       `json:"image"`
+	Resources       *corev1.ResourceRequirements `json:"resources,omitempty"`
+	ImagePullPolicy corev1.PullPolicy            `json:"imagePullPolicy,omitempty"`
+	EnvVars         *[]corev1.EnvVar             `json:"env,omitempty"`
+}

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -58,7 +58,7 @@ type RedisExporter struct {
 type Sidecar struct {
 	Name            string                       `json:"name"`
 	Image           string                       `json:"image"`
-	Resources       *corev1.ResourceRequirements `json:"resources,omitempty"`
 	ImagePullPolicy corev1.PullPolicy            `json:"imagePullPolicy,omitempty"`
+	Resources       *corev1.ResourceRequirements `json:"resources,omitempty"`
 	EnvVars         *[]corev1.EnvVar             `json:"env,omitempty"`
 }

--- a/api/v1beta1/redis_types.go
+++ b/api/v1beta1/redis_types.go
@@ -35,6 +35,7 @@ type RedisSpec struct {
 	PriorityClassName string                     `json:"priorityClassName,omitempty"`
 	Affinity          *corev1.Affinity           `json:"affinity,omitempty"`
 	Tolerations       *[]corev1.Toleration       `json:"tolerations,omitempty"`
+	Sidecars          *[]Sidecar                 `json:"sidecars,omitempty"`
 }
 
 // RedisStatus defines the observed state of Redis

--- a/api/v1beta1/rediscluster_types.go
+++ b/api/v1beta1/rediscluster_types.go
@@ -35,6 +35,7 @@ type RedisClusterSpec struct {
 	PriorityClassName string                       `json:"priorityClassName,omitempty"`
 	Tolerations       *[]corev1.Toleration         `json:"tolerations,omitempty"`
 	Resources         *corev1.ResourceRequirements `json:"resources,omitempty"`
+	Sidecars          *[]Sidecar                   `json:"sidecars,omitempty"`
 }
 
 // RedisLeader interface will have the redis leader configuration

--- a/docs/src/guide/redis-cluster-config.md
+++ b/docs/src/guide/redis-cluster-config.md
@@ -210,6 +210,13 @@ Sidecars for redis pods
   - name: "sidecar1"
     image: "image:1.0"
     imagePullPolicy: Always
+    resources:
+      limits:
+        cpu: 50m
+        memory: 64Mi
+      requests:
+        cpu: 10m
+        memory: 32M
     env:
     - name: VAR_NAME
       value: "value1"

--- a/docs/src/guide/redis-cluster-config.md
+++ b/docs/src/guide/redis-cluster-config.md
@@ -200,3 +200,17 @@ Tolerations for nodes and pods in Kubernetes.
     value: "value1"
     effect: "NoSchedule"
 ```
+
+**sidecars**
+
+Sidecars for redis pods
+
+```yaml
+  sidecars:
+  - name: "sidecar1"
+    image: "image:1.0"
+    imagePullPolicy: Always
+    env:
+    - name: VAR_NAME
+      value: "value1"
+```

--- a/docs/src/guide/redis-cluster-config.md
+++ b/docs/src/guide/redis-cluster-config.md
@@ -42,6 +42,7 @@ In this configuration section, we have these configuration parameters:-
 |`storageSpec` | {} | Storage configuration for redis setup |
 |`securityContext` | {} | Security Context for redis pods for changing system or kernel level parameters |
 |`tolerations` | [] | Tolerations for redis statefulset |
+|`sidecars` | [] | Sidecar for redis pods
 
 # CRD Parameters
 

--- a/docs/src/guide/redis-config.md
+++ b/docs/src/guide/redis-config.md
@@ -179,6 +179,13 @@ Sidecars for redis pods
   - name: "sidecar1"
     image: "image:1.0"
     imagePullPolicy: Always
+    resources:
+      limits:
+        cpu: 50m
+        memory: 64Mi
+      requests:
+        cpu: 10m
+        memory: 32M
     env:
     - name: VAR_NAME
       value: "value1"

--- a/docs/src/guide/redis-config.md
+++ b/docs/src/guide/redis-config.md
@@ -41,6 +41,7 @@ In this configuration section, we have these configuration parameters:-
 |`securityContext` | {} | Security Context for redis pods for changing system or kernel level parameters |
 |`affinity` | {} | Affinity for node and pod for redis statefulset |
 |`tolerations` | [] | Tolerations for redis statefulset |
+|`sidecars` | [] | Sidecar for redis pods
 
 # CRD Parameters
 

--- a/docs/src/guide/redis-config.md
+++ b/docs/src/guide/redis-config.md
@@ -169,3 +169,17 @@ Tolerations for nodes and pods in Kubernetes.
     value: "value1"
     effect: "NoSchedule"
 ```
+
+**sidecars**
+
+Sidecars for redis pods
+
+```yaml
+  sidecars:
+  - name: "sidecar1"
+    image: "image:1.0"
+    imagePullPolicy: Always
+    env:
+    - name: VAR_NAME
+      value: "value1"
+```

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -147,7 +147,7 @@ func (service RedisClusterSTS) CreateRedisClusterSetup(cr *redisv1beta1.RedisClu
 		generateRedisClusterParams(cr, service.getReplicaCount(cr), service.ExternalConfig, service.Affinity),
 		redisClusterAsOwner(cr),
 		generateRedisClusterContainerParams(cr),
-		*cr.Spec.Sidecars,
+		cr.Spec.Sidecars,
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create statefulset for Redis", "Setup.Type", service.RedisStateFulType)

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -191,16 +191,17 @@ func getRedisLabels(name, setupType, role string) map[string]string {
 func generateClusterSidecars(cr *redisv1beta1.RedisCluster /*cr *redisv1beta1.Redis*/) []sidecarParameters {
 	sidecars := []sidecarParameters{}
 
-	if cr.Spec.Sidecars != nil {
-		for _, sidecar := range *cr.Spec.Sidecars {
-			sidecars = append(sidecars, sidecarParameters{
-				Name:            sidecar.Name,
-				Image:           sidecar.Image,
-				ImagePullPolicy: sidecar.ImagePullPolicy,
-				Resources:       sidecar.Resources,
-				EnvVars:         sidecar.EnvVars,
-			})
-		}
+	if cr.Spec.Sidecars == nil {
+		return sidecars
+	}
+	for _, sidecar := range *cr.Spec.Sidecars {
+		sidecars = append(sidecars, sidecarParameters{
+			Name:            sidecar.Name,
+			Image:           sidecar.Image,
+			ImagePullPolicy: sidecar.ImagePullPolicy,
+			Resources:       sidecar.Resources,
+			EnvVars:         sidecar.EnvVars,
+		})
 	}
 	return sidecars
 }

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -147,7 +147,7 @@ func (service RedisClusterSTS) CreateRedisClusterSetup(cr *redisv1beta1.RedisClu
 		generateRedisClusterParams(cr, service.getReplicaCount(cr), service.ExternalConfig, service.Affinity),
 		redisClusterAsOwner(cr),
 		generateRedisClusterContainerParams(cr),
-		generateClusterSidecars(cr),
+		*cr.Spec.Sidecars,
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create statefulset for Redis", "Setup.Type", service.RedisStateFulType)
@@ -185,23 +185,4 @@ func getRedisLabels(name, setupType, role string) map[string]string {
 		"redis_setup_type": setupType,
 		"role":             role,
 	}
-}
-
-// generateSidecars generates Redis sidecar informations
-func generateClusterSidecars(cr *redisv1beta1.RedisCluster) []sidecarParameters {
-	sidecars := []sidecarParameters{}
-
-	if cr.Spec.Sidecars == nil {
-		return sidecars
-	}
-	for _, sidecar := range *cr.Spec.Sidecars {
-		sidecars = append(sidecars, sidecarParameters{
-			Name:            sidecar.Name,
-			Image:           sidecar.Image,
-			ImagePullPolicy: sidecar.ImagePullPolicy,
-			Resources:       sidecar.Resources,
-			EnvVars:         sidecar.EnvVars,
-		})
-	}
-	return sidecars
 }

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -1,8 +1,9 @@
 package k8sutils
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	redisv1beta1 "redis-operator/api/v1beta1"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // RedisClusterSTS is a interface to call Redis Statefulset function
@@ -191,13 +192,13 @@ func generateClusterSidecars(cr *redisv1beta1.RedisCluster /*cr *redisv1beta1.Re
 	sidecars := []sidecarParameters{}
 
 	if cr.Spec.Sidecars != nil {
-		for i := 0; i < len(*cr.Spec.Sidecars); i++ {
+		for _, sidecar := range *cr.Spec.Sidecars {
 			sidecars = append(sidecars, sidecarParameters{
-				Name:            (*cr.Spec.Sidecars)[i].Name,
-				Image:           (*cr.Spec.Sidecars)[i].Image,
-				ImagePullPolicy: (*cr.Spec.Sidecars)[i].ImagePullPolicy,
-				Resources:       (*cr.Spec.Sidecars)[i].Resources,
-				EnvVars:         (*cr.Spec.Sidecars)[i].EnvVars,
+				Name:            sidecar.Name,
+				Image:           sidecar.Image,
+				ImagePullPolicy: sidecar.ImagePullPolicy,
+				Resources:       sidecar.Resources,
+				EnvVars:         sidecar.EnvVars,
 			})
 		}
 	}

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -147,7 +147,7 @@ func (service RedisClusterSTS) CreateRedisClusterSetup(cr *redisv1beta1.RedisClu
 		generateRedisClusterParams(cr, service.getReplicaCount(cr), service.ExternalConfig, service.Affinity),
 		redisClusterAsOwner(cr),
 		generateRedisClusterContainerParams(cr),
-		*cr.Spec.Sidecars,
+		generateClusterSidecars(cr),
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create statefulset for Redis", "Setup.Type", service.RedisStateFulType)
@@ -185,4 +185,23 @@ func getRedisLabels(name, setupType, role string) map[string]string {
 		"redis_setup_type": setupType,
 		"role":             role,
 	}
+}
+
+// generateSidecars generates Redis sidecar informations
+func generateClusterSidecars(cr *redisv1beta1.RedisCluster) []sidecarParameters {
+	sidecars := []sidecarParameters{}
+
+	if cr.Spec.Sidecars == nil {
+		return sidecars
+	}
+	for _, sidecar := range *cr.Spec.Sidecars {
+		sidecars = append(sidecars, sidecarParameters{
+			Name:            sidecar.Name,
+			Image:           sidecar.Image,
+			ImagePullPolicy: sidecar.ImagePullPolicy,
+			Resources:       sidecar.Resources,
+			EnvVars:         sidecar.EnvVars,
+		})
+	}
+	return sidecars
 }

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -146,6 +146,7 @@ func (service RedisClusterSTS) CreateRedisClusterSetup(cr *redisv1beta1.RedisClu
 		generateRedisClusterParams(cr, service.getReplicaCount(cr), service.ExternalConfig, service.Affinity),
 		redisClusterAsOwner(cr),
 		generateRedisClusterContainerParams(cr),
+		generateClusterSidecars(cr),
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create statefulset for Redis", "Setup.Type", service.RedisStateFulType)
@@ -183,4 +184,22 @@ func getRedisLabels(name, setupType, role string) map[string]string {
 		"redis_setup_type": setupType,
 		"role":             role,
 	}
+}
+
+// generateSidecars generates Redis sidecar informations
+func generateClusterSidecars(cr *redisv1beta1.RedisCluster /*cr *redisv1beta1.Redis*/) []sidecarParameters {
+	sidecars := []sidecarParameters{}
+
+	if cr.Spec.Sidecars != nil {
+		for i := 0; i < len(*cr.Spec.Sidecars); i++ {
+			sidecars = append(sidecars, sidecarParameters{
+				Name:            (*cr.Spec.Sidecars)[i].Name,
+				Image:           (*cr.Spec.Sidecars)[i].Image,
+				ImagePullPolicy: (*cr.Spec.Sidecars)[i].ImagePullPolicy,
+				Resources:       (*cr.Spec.Sidecars)[i].Resources,
+				EnvVars:         (*cr.Spec.Sidecars)[i].EnvVars,
+			})
+		}
+	}
+	return sidecars
 }

--- a/k8sutils/redis-cluster.go
+++ b/k8sutils/redis-cluster.go
@@ -187,7 +187,7 @@ func getRedisLabels(name, setupType, role string) map[string]string {
 }
 
 // generateSidecars generates Redis sidecar informations
-func generateClusterSidecars(cr *redisv1beta1.RedisCluster /*cr *redisv1beta1.Redis*/) []sidecarParameters {
+func generateClusterSidecars(cr *redisv1beta1.RedisCluster) []sidecarParameters {
 	sidecars := []sidecarParameters{}
 
 	if cr.Spec.Sidecars != nil {

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -118,13 +118,13 @@ func generateSidecars(cr *redisv1beta1.Redis) []sidecarParameters {
 	sidecars := []sidecarParameters{}
 
 	if cr.Spec.Sidecars != nil {
-		for i := 0; i < len(*cr.Spec.Sidecars); i++ {
+		for _, sidecar := range *cr.Spec.Sidecars {
 			sidecars = append(sidecars, sidecarParameters{
-				Name:            (*cr.Spec.Sidecars)[i].Name,
-				Image:           (*cr.Spec.Sidecars)[i].Image,
-				ImagePullPolicy: (*cr.Spec.Sidecars)[i].ImagePullPolicy,
-				Resources:       (*cr.Spec.Sidecars)[i].Resources,
-				EnvVars:         (*cr.Spec.Sidecars)[i].EnvVars,
+				Name:            sidecar.Name,
+				Image:           sidecar.Image,
+				ImagePullPolicy: sidecar.ImagePullPolicy,
+				Resources:       sidecar.Resources,
+				EnvVars:         sidecar.EnvVars,
 			})
 		}
 	}

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -41,7 +41,7 @@ func CreateStandAloneRedis(cr *redisv1beta1.Redis) error {
 		generateRedisStandaloneParams(cr),
 		redisAsOwner(cr),
 		generateRedisStandaloneContainerParams(cr),
-		*cr.Spec.Sidecars,
+		generateSidecars(cr),
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create standalone statefulset for Redis")
@@ -111,4 +111,22 @@ func generateRedisStandaloneContainerParams(cr *redisv1beta1.Redis) containerPar
 		containerProp.PersistenceEnabled = &trueProperty
 	}
 	return containerProp
+}
+
+// generateSidecars generates Redis sidecar informations
+func generateSidecars(cr *redisv1beta1.Redis) []sidecarParameters {
+	sidecars := []sidecarParameters{}
+
+	if cr.Spec.Sidecars != nil {
+		for _, sidecar := range *cr.Spec.Sidecars {
+			sidecars = append(sidecars, sidecarParameters{
+				Name:            sidecar.Name,
+				Image:           sidecar.Image,
+				ImagePullPolicy: sidecar.ImagePullPolicy,
+				Resources:       sidecar.Resources,
+				EnvVars:         sidecar.EnvVars,
+			})
+		}
+	}
+	return sidecars
 }

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -41,7 +41,7 @@ func CreateStandAloneRedis(cr *redisv1beta1.Redis) error {
 		generateRedisStandaloneParams(cr),
 		redisAsOwner(cr),
 		generateRedisStandaloneContainerParams(cr),
-		generateSidecars(cr),
+		*cr.Spec.Sidecars,
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create standalone statefulset for Redis")
@@ -111,22 +111,4 @@ func generateRedisStandaloneContainerParams(cr *redisv1beta1.Redis) containerPar
 		containerProp.PersistenceEnabled = &trueProperty
 	}
 	return containerProp
-}
-
-// generateSidecars generates Redis sidecar informations
-func generateSidecars(cr *redisv1beta1.Redis) []sidecarParameters {
-	sidecars := []sidecarParameters{}
-
-	if cr.Spec.Sidecars != nil {
-		for _, sidecar := range *cr.Spec.Sidecars {
-			sidecars = append(sidecars, sidecarParameters{
-				Name:            sidecar.Name,
-				Image:           sidecar.Image,
-				ImagePullPolicy: sidecar.ImagePullPolicy,
-				Resources:       sidecar.Resources,
-				EnvVars:         sidecar.EnvVars,
-			})
-		}
-	}
-	return sidecars
 }

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -41,7 +41,7 @@ func CreateStandAloneRedis(cr *redisv1beta1.Redis) error {
 		generateRedisStandaloneParams(cr),
 		redisAsOwner(cr),
 		generateRedisStandaloneContainerParams(cr),
-		*cr.Spec.Sidecars,
+		cr.Spec.Sidecars,
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create standalone statefulset for Redis")

--- a/k8sutils/redis-standalone.go
+++ b/k8sutils/redis-standalone.go
@@ -41,6 +41,7 @@ func CreateStandAloneRedis(cr *redisv1beta1.Redis) error {
 		generateRedisStandaloneParams(cr),
 		redisAsOwner(cr),
 		generateRedisStandaloneContainerParams(cr),
+		generateSidecars(cr),
 	)
 	if err != nil {
 		logger.Error(err, "Cannot create standalone statefulset for Redis")
@@ -110,4 +111,22 @@ func generateRedisStandaloneContainerParams(cr *redisv1beta1.Redis) containerPar
 		containerProp.PersistenceEnabled = &trueProperty
 	}
 	return containerProp
+}
+
+// generateSidecars generates Redis sidecar informations
+func generateSidecars(cr *redisv1beta1.Redis) []sidecarParameters {
+	sidecars := []sidecarParameters{}
+
+	if cr.Spec.Sidecars != nil {
+		for i := 0; i < len(*cr.Spec.Sidecars); i++ {
+			sidecars = append(sidecars, sidecarParameters{
+				Name:            (*cr.Spec.Sidecars)[i].Name,
+				Image:           (*cr.Spec.Sidecars)[i].Image,
+				ImagePullPolicy: (*cr.Spec.Sidecars)[i].ImagePullPolicy,
+				Resources:       (*cr.Spec.Sidecars)[i].Resources,
+				EnvVars:         (*cr.Spec.Sidecars)[i].EnvVars,
+			})
+		}
+	}
+	return sidecars
 }

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -2,6 +2,7 @@ package k8sutils
 
 import (
 	"context"
+	redisv1beta1 "redis-operator/api/v1beta1"
 	"sort"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -47,16 +48,8 @@ type containerParameters struct {
 	PersistenceEnabled           *bool
 }
 
-type sidecarParameters struct {
-	Name            string
-	Image           string
-	ImagePullPolicy corev1.PullPolicy
-	Resources       *corev1.ResourceRequirements
-	EnvVars         *[]corev1.EnvVar
-}
-
 // CreateOrUpdateStateFul method will create or update Redis service
-func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []sidecarParameters) error {
+func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []redisv1beta1.Sidecar) error {
 	logger := stateFulSetLogger(namespace, stsMeta.Name)
 	storedStateful, err := GetStateFulSet(namespace, stsMeta.Name)
 	statefulSetDef := generateStateFulSetsDef(stsMeta, labels, params, ownerDef, containerParams, sidecars)
@@ -100,7 +93,7 @@ func patchStateFulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 }
 
 // generateStateFulSetsDef generates the statefulsets definition of Redis
-func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecarsParams []sidecarParameters) *appsv1.StatefulSet {
+func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecarsParams []redisv1beta1.Sidecar) *appsv1.StatefulSet {
 	statefulset := &appsv1.StatefulSet{
 		TypeMeta:   generateMetaInformation("StatefulSet", "apps/v1"),
 		ObjectMeta: stsMeta,
@@ -171,7 +164,7 @@ func createPVCTemplate(name string, storageSpec corev1.PersistentVolumeClaim) co
 }
 
 // generateContainerDef generates container fefinition for Redis
-func generateContainerDef(name string, containerParams containerParameters, enableMetrics bool, externalConfig *string, sidecars []sidecarParameters) []corev1.Container {
+func generateContainerDef(name string, containerParams containerParameters, enableMetrics bool, externalConfig *string, sidecars []redisv1beta1.Sidecar) []corev1.Container {
 	containerDefinition := []corev1.Container{
 		{
 			Name:            name,

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -49,10 +49,10 @@ type containerParameters struct {
 }
 
 // CreateOrUpdateStateFul method will create or update Redis service
-func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []redisv1beta1.Sidecar) error {
+func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars *[]redisv1beta1.Sidecar) error {
 	logger := stateFulSetLogger(namespace, stsMeta.Name)
 	storedStateful, err := GetStateFulSet(namespace, stsMeta.Name)
-	statefulSetDef := generateStateFulSetsDef(stsMeta, labels, params, ownerDef, containerParams, sidecars)
+	statefulSetDef := generateStateFulSetsDef(stsMeta, labels, params, ownerDef, containerParams, getSidecars(sidecars))
 	if err != nil {
 		if err := patch.DefaultAnnotator.SetLastAppliedAnnotation(statefulSetDef); err != nil {
 			logger.Error(err, "Unable to patch redis statefulset with comparison object")
@@ -93,7 +93,7 @@ func patchStateFulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 }
 
 // generateStateFulSetsDef generates the statefulsets definition of Redis
-func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecarsParams []redisv1beta1.Sidecar) *appsv1.StatefulSet {
+func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []redisv1beta1.Sidecar) *appsv1.StatefulSet {
 	statefulset := &appsv1.StatefulSet{
 		TypeMeta:   generateMetaInformation("StatefulSet", "apps/v1"),
 		ObjectMeta: stsMeta,
@@ -106,7 +106,7 @@ func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					Containers:        generateContainerDef(stsMeta.Name, containerParams, params.EnableMetrics, params.ExternalConfig, sidecarsParams),
+					Containers:        generateContainerDef(stsMeta.Name, containerParams, params.EnableMetrics, params.ExternalConfig, sidecars),
 					NodeSelector:      params.NodeSelector,
 					SecurityContext:   params.SecurityContext,
 					PriorityClassName: params.PriorityClassName,
@@ -183,13 +183,18 @@ func generateContainerDef(name string, containerParams containerParameters, enab
 		containerDefinition = append(containerDefinition, enableRedisMonitoring(containerParams))
 	}
 	for _, sidecar := range sidecars {
-		containerDefinition = append(containerDefinition, corev1.Container{
+		container := corev1.Container{
 			Name:            sidecar.Name,
 			Image:           sidecar.Image,
 			ImagePullPolicy: sidecar.ImagePullPolicy,
-			Resources:       *sidecar.Resources,
-			Env:             *sidecar.EnvVars,
-		})
+		}
+		if sidecar.Resources != nil {
+			container.Resources = *sidecar.Resources
+		}
+		if sidecar.EnvVars != nil {
+			container.Env = *sidecar.EnvVars
+		}
+		containerDefinition = append(containerDefinition, container)
 	}
 	return containerDefinition
 }
@@ -320,4 +325,11 @@ func GetStateFulSet(namespace string, stateful string) (*appsv1.StatefulSet, err
 func stateFulSetLogger(namespace string, name string) logr.Logger {
 	reqLogger := log.WithValues("Request.StateFulSet.Namespace", namespace, "Request.StateFulSet.Name", name)
 	return reqLogger
+}
+
+func getSidecars(sidecars *[]redisv1beta1.Sidecar) []redisv1beta1.Sidecar {
+	if sidecars == nil {
+		return []redisv1beta1.Sidecar{}
+	}
+	return *sidecars
 }

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -2,6 +2,7 @@ package k8sutils
 
 import (
 	"context"
+	redisv1beta1 "redis-operator/api/v1beta1"
 	"sort"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -47,16 +48,8 @@ type containerParameters struct {
 	PersistenceEnabled           *bool
 }
 
-type sidecarParameters struct {
-	Name            string
-	Image           string
-	ImagePullPolicy corev1.PullPolicy
-	Resources       *corev1.ResourceRequirements
-	EnvVars         *[]corev1.EnvVar
-}
-
 // CreateOrUpdateStateFul method will create or update Redis service
-func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []sidecarParameters) error {
+func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []redisv1beta1.Sidecar) error {
 	logger := stateFulSetLogger(namespace, stsMeta.Name)
 	storedStateful, err := GetStateFulSet(namespace, stsMeta.Name)
 	statefulSetDef := generateStateFulSetsDef(stsMeta, labels, params, ownerDef, containerParams, sidecars)
@@ -100,7 +93,7 @@ func patchStateFulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 }
 
 // generateStateFulSetsDef generates the statefulsets definition of Redis
-func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecarsParams []sidecarParameters) *appsv1.StatefulSet {
+func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecarsParams []redisv1beta1.Sidecar) *appsv1.StatefulSet {
 	statefulset := &appsv1.StatefulSet{
 		TypeMeta:   generateMetaInformation("StatefulSet", "apps/v1"),
 		ObjectMeta: stsMeta,
@@ -171,7 +164,7 @@ func createPVCTemplate(name string, storageSpec corev1.PersistentVolumeClaim) co
 }
 
 // generateContainerDef generates container fefinition for Redis
-func generateContainerDef(name string, containerParams containerParameters, enableMetrics bool, externalConfig *string, sidecars []sidecarParameters) []corev1.Container {
+func generateContainerDef(name string, containerParams containerParameters, enableMetrics bool, externalConfig *string, sidecars []redisv1beta1.Sidecar) []corev1.Container {
 	containerDefinition := []corev1.Container{
 		{
 			Name:            name,
@@ -190,7 +183,7 @@ func generateContainerDef(name string, containerParams containerParameters, enab
 		containerDefinition = append(containerDefinition, enableRedisMonitoring(containerParams))
 	}
 	for _, sidecar := range sidecars {
-		sidecars = append(sidecars, sidecarParameters{
+		sidecars = append(sidecars, redisv1beta1.Sidecar{
 			Name:            sidecar.Name,
 			Image:           sidecar.Image,
 			ImagePullPolicy: sidecar.ImagePullPolicy,

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -189,13 +189,13 @@ func generateContainerDef(name string, containerParams containerParameters, enab
 	if enableMetrics {
 		containerDefinition = append(containerDefinition, enableRedisMonitoring(containerParams))
 	}
-	for i := 0; i < len(sidecars); i++ {
-		containerDefinition = append(containerDefinition, corev1.Container{
-			Name:            sidecars[i].Name,
-			Image:           sidecars[i].Image,
-			ImagePullPolicy: sidecars[i].ImagePullPolicy,
-			Resources:       *sidecars[i].Resources,
-			Env:             *sidecars[i].EnvVars,
+	for _, sidecar := range sidecars {
+		sidecars = append(sidecars, sidecarParameters{
+			Name:            sidecar.Name,
+			Image:           sidecar.Image,
+			ImagePullPolicy: sidecar.ImagePullPolicy,
+			Resources:       sidecar.Resources,
+			EnvVars:         sidecar.EnvVars,
 		})
 	}
 	return containerDefinition

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -2,7 +2,6 @@ package k8sutils
 
 import (
 	"context"
-	redisv1beta1 "redis-operator/api/v1beta1"
 	"sort"
 
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -48,8 +47,16 @@ type containerParameters struct {
 	PersistenceEnabled           *bool
 }
 
+type sidecarParameters struct {
+	Name            string
+	Image           string
+	ImagePullPolicy corev1.PullPolicy
+	Resources       *corev1.ResourceRequirements
+	EnvVars         *[]corev1.EnvVar
+}
+
 // CreateOrUpdateStateFul method will create or update Redis service
-func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []redisv1beta1.Sidecar) error {
+func CreateOrUpdateStateFul(namespace string, stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecars []sidecarParameters) error {
 	logger := stateFulSetLogger(namespace, stsMeta.Name)
 	storedStateful, err := GetStateFulSet(namespace, stsMeta.Name)
 	statefulSetDef := generateStateFulSetsDef(stsMeta, labels, params, ownerDef, containerParams, sidecars)
@@ -93,7 +100,7 @@ func patchStateFulSet(storedStateful *appsv1.StatefulSet, newStateful *appsv1.St
 }
 
 // generateStateFulSetsDef generates the statefulsets definition of Redis
-func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecarsParams []redisv1beta1.Sidecar) *appsv1.StatefulSet {
+func generateStateFulSetsDef(stsMeta metav1.ObjectMeta, labels map[string]string, params statefulSetParameters, ownerDef metav1.OwnerReference, containerParams containerParameters, sidecarsParams []sidecarParameters) *appsv1.StatefulSet {
 	statefulset := &appsv1.StatefulSet{
 		TypeMeta:   generateMetaInformation("StatefulSet", "apps/v1"),
 		ObjectMeta: stsMeta,
@@ -164,7 +171,7 @@ func createPVCTemplate(name string, storageSpec corev1.PersistentVolumeClaim) co
 }
 
 // generateContainerDef generates container fefinition for Redis
-func generateContainerDef(name string, containerParams containerParameters, enableMetrics bool, externalConfig *string, sidecars []redisv1beta1.Sidecar) []corev1.Container {
+func generateContainerDef(name string, containerParams containerParameters, enableMetrics bool, externalConfig *string, sidecars []sidecarParameters) []corev1.Container {
 	containerDefinition := []corev1.Container{
 		{
 			Name:            name,
@@ -183,7 +190,7 @@ func generateContainerDef(name string, containerParams containerParameters, enab
 		containerDefinition = append(containerDefinition, enableRedisMonitoring(containerParams))
 	}
 	for _, sidecar := range sidecars {
-		sidecars = append(sidecars, redisv1beta1.Sidecar{
+		sidecars = append(sidecars, sidecarParameters{
 			Name:            sidecar.Name,
 			Image:           sidecar.Image,
 			ImagePullPolicy: sidecar.ImagePullPolicy,

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -190,12 +190,12 @@ func generateContainerDef(name string, containerParams containerParameters, enab
 		containerDefinition = append(containerDefinition, enableRedisMonitoring(containerParams))
 	}
 	for _, sidecar := range sidecars {
-		sidecars = append(sidecars, sidecarParameters{
+		containerDefinition = append(containerDefinition, corev1.Container{
 			Name:            sidecar.Name,
 			Image:           sidecar.Image,
 			ImagePullPolicy: sidecar.ImagePullPolicy,
-			Resources:       sidecar.Resources,
-			EnvVars:         sidecar.EnvVars,
+			Resources:       *sidecar.Resources,
+			Env:             *sidecar.EnvVars,
 		})
 	}
 	return containerDefinition


### PR DESCRIPTION
Implement support to create sidecar for the redis (slave and follower) pods, from the CRD Redis/RedisCluster. A new struct "sidecarparemeters" and generation functions have been added.